### PR TITLE
fix uninitialized csv_user_attributes class variable

### DIFF
--- a/app/models/rapidfire/survey.rb
+++ b/app/models/rapidfire/survey.rb
@@ -16,7 +16,7 @@ module Rapidfire
     end
 
     def self.csv_user_attributes
-      @@csv_user_attributes || []
+      @@csv_user_attributes ||= []
     end
 
     def results_to_csv(filter)


### PR DESCRIPTION
I am getting error on `Download CSV` action.

I've used ||=(or-equal) operator to fix this issue.

### Error details
NameError in Rapidfire::SurveysController#results
uninitialized class variable @@csv_user_attributes in Rapidfire::Survey

> [rapidfire (5.0.0) app/models/rapidfire/survey.rb:19:in `csv_user_attributes'](http://localhost:3000/rapidfire/surveys/1/results.csv#)
[rapidfire (5.0.0) app/models/rapidfire/survey.rb:25:in `block in results_to_csv'](http://localhost:3000/rapidfire/surveys/1/results.csv#)
....
....