### PR TITLE
Fix: resolve delete error

### DIFF
--- a/app/views/rapidfire/questions/_question.html.erb
+++ b/app/views/rapidfire/questions/_question.html.erb
@@ -3,7 +3,7 @@
   <td>
     <ul class="horizontal-list">
       <li><%= link_to "Edit", [:edit, question.survey, question] %></li>
-      <li><%= link_to "Delete", [question.survey, question], method: :delete %></li>
+      <li><%= button_to "Delete", [question.survey, question], method: :delete %></li>
     </ul>
   </td>
 </tr>

--- a/app/views/rapidfire/surveys/_survey.html.erb
+++ b/app/views/rapidfire/surveys/_survey.html.erb
@@ -13,7 +13,7 @@
         <li><%= link_to "Results", [:results, survey] %></li>
         <li><%= link_to "Edit", edit_survey_path(survey) %></li>
         <li><%= link_to "Copy", surveys_path(copy_survey_id: survey), method: :post %></li>
-        <li><%= link_to "Delete", survey, method: :delete %></li>
+        <li><%= button_to "Delete", survey, method: :delete %></li>
         <% if survey.active? %>
           <li><%= link_to "De-activate", survey_path(survey, survey: { active: 0 }), method: :patch %></li>
         <% else %>


### PR DESCRIPTION
### **Issue**

The delete functionality was not working for surveys and questions.

### **Reason**

The link_to helper was being used for the delete method, which caused the delete request to not be sent correctly.

### **Approach**

Replaced the link_to helper with the button_to helper, ensuring that the delete HTTP request is properly passed and handled.

### **Impact**

The delete functionality now works as expected for surveys and questions.

### **Screenshot of the Error**

![Screenshot 2024-11-28 192234](https://github.com/user-attachments/assets/0bb9e612-a2eb-4737-a340-a67e852312e1)

Before


https://github.com/user-attachments/assets/3f126f48-c33a-4fc1-862c-46930e763308



After

https://github.com/user-attachments/assets/b42e36d5-1dbb-4526-9475-82246b365c3b


