### PR TITLE
Add support for single and multiple file attachments to Questions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ gem 'ostruct'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '~> 2.13.0'
   gem 'selenium-webdriver'
   gem 'pry-rails'
 end

--- a/app/models/rapidfire/question.rb
+++ b/app/models/rapidfire/question.rb
@@ -2,6 +2,9 @@ module Rapidfire
   class Question < ApplicationRecord
     belongs_to :survey, :inverse_of => :questions
     has_many   :answers
+    
+    has_many_attached :files
+
 
     default_scope { order(:position) }
 

--- a/app/views/rapidfire/answers/_file.html.erb
+++ b/app/views/rapidfire/answers/_file.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: "rapidfire/answers/errors", locals: {answer: answer} %>
 <div class="form-group">
+<%= render partial: 'rapidfire/answers/file_attachment', locals: { answer: answer } %>
 <%= f.label :answer_text, answer.question.question_text.html_safe %>
 <%= f.file_field :file %>
 </div>

--- a/app/views/rapidfire/answers/_file_attachment.html.erb
+++ b/app/views/rapidfire/answers/_file_attachment.html.erb
@@ -1,0 +1,8 @@
+<% if answer.question.files.attached? %>
+  <p><strong>Attached Files:</strong></p>
+  <% answer.question.files.each do |file| %>
+    <p>
+      <%= link_to file.filename.to_s, main_app.url_for(file), target: "_blank" %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/rapidfire/answers/_multifile.html.erb
+++ b/app/views/rapidfire/answers/_multifile.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: "rapidfire/answers/errors", locals: {answer: answer} %>
 <div class="form-group">
+<%= render partial: 'rapidfire/answers/file_attachment', locals: { answer: answer } %>
 <%= f.label :answer_text, answer.question.question_text.html_safe %>
 <%= f.file_field :files, multiple: true %>
 </div>

--- a/app/views/rapidfire/questions/_form.html.erb
+++ b/app/views/rapidfire/questions/_form.html.erb
@@ -39,6 +39,11 @@
     <%= f.text_area :answer_options, rows: 5 %>
   </div>
 
+  <div class="form-group">
+    <%= f.label :files, "Attach Multiple Files" %>
+    <%= f.file_field :files, multiple: true %>
+  </div>
+
     <h4>Other options</h4>
     <hr/>
 

--- a/spec/features/rapidfire/managing_questions_spec.rb
+++ b/spec/features/rapidfire/managing_questions_spec.rb
@@ -14,7 +14,7 @@ describe "Questions" do
       visit rapidfire.survey_questions_path(survey)
 
       page.within("#question_#{question1.id}") do
-        click_link "Delete"
+        click_button "Delete"
       end
     end
 

--- a/spec/features/rapidfire/managing_surveys_spec.rb
+++ b/spec/features/rapidfire/managing_surveys_spec.rb
@@ -27,7 +27,7 @@ describe "Surveys" do
         allow_any_instance_of(ApplicationController).to receive(:can_administer?).and_return(true)
 
         visit rapidfire.root_path
-        click_link "Delete"
+        click_button "Delete"
       end
 
       it "deletes the survey" do


### PR DESCRIPTION
### **Add support for file attachments to Questions**

### **Summary:**

- Enhanced the Question model to support file attachments.
- Updated the QuestionForm service to handle file uploads dynamically
- Modified the form view to allow multiple file uploads.
- Conditionally rendered attached files in the view, including the option to open files in a new tab.

### **Key Changes:**
Model Changes:

- Added has_many_attached :files to the Question model 

Service Changes:

- Updated the QuestionForm to handle attaching multiple files (files)
- Implemented logic in the attach_files method to attach files accordingly.

Form Changes:

- Updated the form to accept file uploads.

View Changes:

- Conditionally rendered attached files, ensuring that if multiple files are attached, each file is displayed as a separate link.


Recording:

https://github.com/user-attachments/assets/85e501c6-b330-4899-a1a5-fb08a2c970e6





